### PR TITLE
Rename abilities for Sinless

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2,10 +2,10 @@
   "SINLESS": {
     "Ability": {
       "Str": { "long": "Strength", "abbr": "str" },
-      "Con": { "long": "Constitution", "abbr": "con" },
-      "Dex": { "long": "Dexterity", "abbr": "dex" },
+      "Bod": { "long": "Body", "abbr": "bod" },
+      "Rct": { "long": "Reaction", "abbr": "rct" },
       "Int": { "long": "Intelligence", "abbr": "int" },
-      "Wis": { "long": "Wisdom", "abbr": "wis" },
+      "Wlp": { "long": "Willpower", "abbr": "wlp" },
       "Cha": { "long": "Charisma", "abbr": "cha" }
     },
     "SheetLabels": {

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -6,18 +6,18 @@ export const SINLESS = {};
  */
 SINLESS.abilities = {
   str: 'SINLESS.Ability.Str.long',
-  dex: 'SINLESS.Ability.Dex.long',
-  con: 'SINLESS.Ability.Con.long',
+  bod: 'SINLESS.Ability.Bod.long',
+  rct: 'SINLESS.Ability.Rct.long',
   int: 'SINLESS.Ability.Int.long',
-  wis: 'SINLESS.Ability.Wis.long',
+  wlp: 'SINLESS.Ability.Wlp.long',
   cha: 'SINLESS.Ability.Cha.long',
 };
 
 SINLESS.abilityAbbreviations = {
   str: 'SINLESS.Ability.Str.abbr',
-  dex: 'SINLESS.Ability.Dex.abbr',
-  con: 'SINLESS.Ability.Con.abbr',
+  bod: 'SINLESS.Ability.Bod.abbr',
+  rct: 'SINLESS.Ability.Rct.abbr',
   int: 'SINLESS.Ability.Int.abbr',
-  wis: 'SINLESS.Ability.Wis.abbr',
+  wlp: 'SINLESS.Ability.Wlp.abbr',
   cha: 'SINLESS.Ability.Cha.abbr',
 };


### PR DESCRIPTION
Changing ability names to match Sinless.

The Sinless rulebook also uses the term "attributes" instead of "abilities". We should consider doing the same.